### PR TITLE
fix can not copy <my-project>/default.css

### DIFF
--- a/src/coo.lisp
+++ b/src/coo.lisp
@@ -144,7 +144,8 @@ If :param:`discover-packages` is true (the default), it will try to figure out a
         (document-package package base-path)))
 
   ;; Copy styles to new directory
-  (uiop:copy-file #P"default.css" (merge-pathnames #P"default.css" base-path)))
+  (uiop:copy-file (asdf:system-relative-pathname :coo "default.css")
+                  (merge-pathnames #P"default.css" base-path)))
 
 
 (defun system-collect-metadata (system stream)


### PR DESCRIPTION
fixes #2 

(quick fix)

Also, I remember having observed a slow-down of an executable of mine at start-up because of asdf:…relative-pathname. It may have been just my current config. Just sharing a warning.