### PR TITLE
Now Coo can build documentation for package inferred asdf systems.

### DIFF
--- a/src/roles.lisp
+++ b/src/roles.lisp
@@ -78,7 +78,10 @@ which lets you make references in your docstrings!"
   `(def-role ,thing (symbol)
      (if-let ((found-symbol (find-symbol-by-name symbol)))
        (let ((node (docutils:make-node 'docutils.nodes:reference
-                                       :refuri (coo.util:make-url nil (symbol-package found-symbol) (symbol-name found-symbol) ,(string-downcase thing))
+                                       :refuri (coo.util:make-url nil
+                                                                  (symbol-package found-symbol)
+                                                                  (symbol-name found-symbol)
+                                                                  ,(string-downcase thing))
                                        :class ,(concatenate 'string "ref-" (string-downcase thing)))))
 
          (docutils:add-child node (name-symbol found-symbol))

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -2,11 +2,35 @@
   (:use #:cl #:alexandria #:cl-arrows)
 
   (:export #:make-url
-	   #:make-anchor)
+	   #:make-anchor
+           #:with-root
+           #:root)
 
   (:documentation "Package for utilities that help multiple other coo packages.  Things like reliably generating urls."))
 
 (in-package :coo.util)
+
+
+(defvar *root* ""
+  "Path to be used in the URL as a prefix.
+
+For example, let's pretend we have base-path = \"docs\" and are generating
+page docs/example/sub/package.html.
+
+Then to link from that page to a function described at the docs/example/other-sub.html
+we have to use *root* = \"../../\". And the link will be: ../../example/other-sub.html
+
+To manipulate with this var, use with-root macro and root function.
+")
+
+
+(defmacro with-root ((new-root) &body body)
+  `(let ((*root* ,new-root))
+     ,@body))
+
+
+(defun root ()
+  *root*)
 
 
 (defun make-url (stream package &optional symbol-name type)
@@ -19,7 +43,8 @@
     ((equal package (find-package :common-lisp))
      (hyperspec:lookup symbol-name))
     (t
-     (format stream "~(~a~).html~@[#~*~a~]"
+     (format stream "~a~(~a~).html~@[#~*~a~]"
+             (root)
              (package-name package)
              symbol-name
              (make-anchor nil symbol-name type)))))

--- a/templates/package-index.rst
+++ b/templates/package-index.rst
@@ -1,6 +1,6 @@
 {{ package.name |format:"``~(~a~)`` package" |title }}
 
-`<< back to {{ system.name }} index <index.html>`_
+`<< back to {{ system.name }} index <{{ root-dir }}index.html>`_
 
 {{ package.docstring }}
 


### PR DESCRIPTION
Example can be found here:

https://cl-doc-systems.github.io/coo

This commit fixes paths for documents placed into the nested subdirectories.